### PR TITLE
Track pickup form leads in Google Analytics and Tag Manager.

### DIFF
--- a/src/components/PickupForm.tsx
+++ b/src/components/PickupForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { reportAdsConversion, trackEvent } from "@/lib/analytics";
 
 interface FormData {
   firstName: string;
@@ -180,26 +181,6 @@ export default function PickupForm({ onClose }: PickupFormProps) {
     }
   };
 
-  const gtag_report_conversion = (url?: string) => {
-    if (typeof window !== "undefined") {
-      const gtag = (window as Window & { gtag?: (...args: unknown[]) => void }).gtag;
-
-      if (gtag) {
-        const callback = () => {
-          if (typeof url !== "undefined" && url) {
-            window.location.href = url;
-          }
-        };
-
-        gtag("event", "conversion", {
-          send_to: "AW-17836566328/8pSKCJO5q9obELjOkblC",
-          event_callback: callback,
-        });
-      }
-    }
-    return false;
-  };
-
   const submitInitialLead = async () => {
     setIsSubmittingInitial(true);
     setSubmitStatus("idle");
@@ -216,7 +197,11 @@ export default function PickupForm({ onClose }: PickupFormProps) {
       });
 
       if (response.ok) {
-        gtag_report_conversion();
+        trackEvent("generate_lead", {
+          form_name: "pickup_request",
+          submission_type: "initial",
+        });
+        reportAdsConversion();
         setShowContactCapturedBanner(true);
         setCurrentStep(2);
       } else {
@@ -245,6 +230,12 @@ export default function PickupForm({ onClose }: PickupFormProps) {
       });
 
       if (response.ok) {
+        trackEvent("pickup_form_complete", {
+          form_name: "pickup_request",
+          submission_type: "supplemental",
+          services: formData.services.join(",") || "none",
+          estimated_quantity: formData.estimatedQuantity || "unspecified",
+        });
         setSubmittedSupplementalDetails(true);
         setSubmitStatus("success");
         setFormData(emptyForm());

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,54 @@
+type AnalyticsParams = Record<string, string | number | boolean | undefined>;
+
+declare global {
+  interface Window {
+    dataLayer?: Record<string, unknown>[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+const ADS_CONVERSION_SEND_TO = "AW-17836566328/8pSKCJO5q9obELjOkblC";
+
+function getGtag() {
+  if (typeof window === "undefined") return undefined;
+  return window.gtag;
+}
+
+/**
+ * Fires a custom event to dataLayer (GTM) and gtag (Google tag destinations).
+ * Do not include PII (name, email, phone) in params.
+ */
+export function trackEvent(eventName: string, params?: AnalyticsParams) {
+  if (typeof window === "undefined") return;
+
+  const payload = {
+    event: eventName,
+    ...params,
+  };
+
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(payload);
+
+  const gtag = getGtag();
+  if (gtag) {
+    gtag("event", eventName, params ?? {});
+  }
+}
+
+export function reportAdsConversion(url?: string) {
+  const gtag = getGtag();
+  if (!gtag) return false;
+
+  const callback = () => {
+    if (url) {
+      window.location.href = url;
+    }
+  };
+
+  gtag("event", "conversion", {
+    send_to: ADS_CONVERSION_SEND_TO,
+    event_callback: callback,
+  });
+
+  return false;
+}


### PR DESCRIPTION
Fire generate_lead and pickup_form_complete on successful submits so GA4 and GTM can record conversions alongside the existing Ads tag.