### PR TITLE
Refine homepage SEO copy for ITAD positioning and sitewide consistency.

### DIFF
--- a/src/app/about/AboutPageContent.tsx
+++ b/src/app/about/AboutPageContent.tsx
@@ -99,10 +99,12 @@ export default function AboutPageContent() {
                   <div className="text-center">
                     <div className="text-4xl font-bold mb-2">5M+</div>
                     <div className="text-sm opacity-90">Devices Processed</div>
+                    <div className="text-xs opacity-75 mt-1">Since 2004</div>
                   </div>
                   <div className="text-center">
                     <div className="text-4xl font-bold mb-2">700+</div>
                     <div className="text-sm opacity-90">Businesses Served</div>
+                    <div className="text-xs opacity-75 mt-1">Since 2004</div>
                   </div>
                   <div className="text-center">
                     <div className="text-4xl font-bold mb-2">100%</div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,8 +6,6 @@ export const metadata: Metadata = {
     "About Computer Recyclers USA | R2 Certified IT Recycling Georgia Since 2004",
   description:
     "Leading Georgia and Southeast's responsible electronics recycling industry for 20+ years. R2 v3, ISO certified facility in Suwanee, GA. Free IT equipment pickup, secure data destruction, and IT Asset Disposition throughout Georgia and Southeast States.",
-  keywords:
-    "Computer Recyclers USA about, IT recycling Georgia Southeast history, R2 certified facility Suwanee GA, responsible electronic waste recycling company Atlanta, data destruction services Georgia, computer recycling company history, ISO certified electronics recycler, Georgia Southeast IT asset disposition company, Suwanee computer recycling facility, Atlanta area e-waste management",
   alternates: {
     canonical: "https://www.crusallc.com/about",
   },

--- a/src/app/certificates/layout.tsx
+++ b/src/app/certificates/layout.tsx
@@ -5,8 +5,6 @@ export const metadata: Metadata = {
     "Certificates & Certifications | Computer Recyclers USA - R2v3 & ISO Certified",
   description:
     "View our certifications: R2v3, ISO 9001, ISO 14001, and ISO 45001. Computer Recyclers USA is a fully certified electronics recycling and data destruction facility in Suwanee, Georgia.",
-  keywords:
-    "R2v3 certified, ISO 9001, ISO 14001, ISO 45001, certifications, computer recyclers USA certificates, R2v3 certification, ISO certified recycler Georgia, certified electronics recycling facility",
   alternates: {
     canonical: "https://www.crusallc.com/certificates",
   },

--- a/src/app/faq/layout.tsx
+++ b/src/app/faq/layout.tsx
@@ -8,8 +8,6 @@ export const metadata: Metadata = {
   title:
     "FAQs | Computer Recyclers USA | Data Destruction, Pickup & Recycling Georgia",
   description: FAQ_PAGE_DESCRIPTION,
-  keywords:
-    "electronics recycling FAQ, data destruction FAQ, NIST 800-88 Georgia, R2 certified recycler FAQ, free IT pickup Georgia, secure data destruction FAQ, HIPAA electronics recycling Georgia",
   alternates: {
     canonical: "https://www.crusallc.com/faq",
   },
@@ -143,7 +141,7 @@ const faqStructuredData = {
       "@type": "Service",
       name: "Responsible Electronics Recycling Services",
       description:
-        "R2 v3 certified electronics recycling in Georgia. Zero landfill guarantee, EPA compliant processes, detailed environmental impact reporting.",
+        "R2 v3 certified electronics recycling in Georgia. Zero landfill guarantee, documented downstream tracking, detailed environmental impact reporting.",
       url: "https://www.crusallc.com/services/responsible-electronics-recycling",
       areaServed: {
         "@type": "State",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,11 +16,9 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Atlanta Computer Recycling | Computer Recyclers USA Georgia",
+  title: "Atlanta Computer Recycling & ITAD | Computer Recyclers USA",
   description:
-    "Atlanta computer recycling by trusted computer recyclers. R2 certified, free pickup, secure data destruction. Serving Atlanta metro & all Georgia.",
-  keywords:
-    "atlanta computer recycling, computer recyclers, recycle computers atlanta, electronics recycling, data destruction, e-waste, georgia, R2 certified",
+    "R2v3-certified computer recycling and ITAD in Atlanta. Hard drive shredding, logical data sanitization, free business pickup across Georgia.",
   authors: [{ name: "Computer Recyclers USA" }],
   creator: "Computer Recyclers USA",
   publisher: "Computer Recyclers USA",
@@ -36,9 +34,9 @@ export const metadata: Metadata = {
     },
   },
   openGraph: {
-    title: "Atlanta Computer Recycling | Computer Recyclers USA",
+    title: "Atlanta Computer Recycling & ITAD | Computer Recyclers USA",
     description:
-      "Atlanta computer recycling by trusted computer recyclers. R2 certified, free pickup, secure data destruction. Serving Atlanta metro & all Georgia.",
+      "R2v3-certified computer recycling and ITAD in Atlanta. Hard drive shredding, logical data sanitization, free business pickup across Georgia.",
     url: "https://www.crusallc.com",
     siteName: "Computer Recyclers USA",
     locale: "en_US",
@@ -54,9 +52,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Atlanta Computer Recycling | Computer Recyclers USA",
+    title: "Atlanta Computer Recycling & ITAD | Computer Recyclers USA",
     description:
-      "Atlanta computer recycling by trusted computer recyclers. R2 certified, free pickup, secure data destruction. Serving Atlanta metro & all Georgia.",
+      "R2v3-certified computer recycling and ITAD in Atlanta. Hard drive shredding, logical data sanitization, free business pickup across Georgia.",
     images: ["https://www.crusallc.com/logo.png"],
   },
   verification: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import PickupForm from "@/components/PickupForm";
 import Header from "@/components/Header";
 import ParticleBackground from "@/components/ParticleBackground";
+import ServiceAreaCallout from "@/components/ServiceAreaCallout";
 import { Analytics } from "@vercel/analytics/react";
 
 export default function Home() {
@@ -24,17 +25,16 @@ export default function Home() {
         <div className="relative z-[1] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center animate-fade-in">
             <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-gray-900 mb-4 sm:mb-6">
-              Atlanta Computer Recycling &
+              Atlanta Computer Recycling,{" "}
               <span className="text-primary-green">
-                {" "}
-                Secure Data Destruction
+                Data Destruction & IT Asset Disposition
               </span>
             </h1>
             <p className="text-lg sm:text-xl md:text-2xl text-gray-600 max-w-4xl mx-auto mb-6 sm:mb-8 px-2">
               <strong>
-                Trusted computer recyclers providing data destruction,
-                electronics recycling, and IT Asset Disposition services for
-                businesses across Atlanta, Georgia and Southeast States
+                R2v3-certified ITAD for Georgia businesses — certified data
+                destruction, logical data sanitization, and value recovery on
+                retired IT assets. Free pickup statewide.
               </strong>
             </p>
             <div className="flex justify-center px-4">
@@ -77,19 +77,22 @@ export default function Home() {
                 </div>
               </div>
             </div>
-            <div className="grid grid-cols-3 gap-4 sm:gap-6 md:gap-8 text-xs sm:text-sm">
-              <div className="text-center">
-                <div className="font-bold text-lg sm:text-xl text-primary-green">
-                  5M+
+            <div className="text-center">
+              <div className="grid grid-cols-2 gap-4 sm:gap-6 md:gap-8 text-xs sm:text-sm">
+                <div>
+                  <div className="font-bold text-lg sm:text-xl text-primary-green">
+                    5M+
+                  </div>
+                  <div className="text-gray-600 text-xs">Devices Processed</div>
                 </div>
-                <div className="text-gray-600 text-xs">Devices Processed</div>
-              </div>
-              <div className="text-center">
-                <div className="font-bold text-lg sm:text-xl text-primary-green">
-                  700+
+                <div>
+                  <div className="font-bold text-lg sm:text-xl text-primary-green">
+                    700+
+                  </div>
+                  <div className="text-gray-600 text-xs">Businesses Served</div>
                 </div>
-                <div className="text-gray-600 text-xs">Businesses Served</div>
               </div>
+              <div className="text-gray-500 text-xs mt-1">Since 2004</div>
             </div>
           </div>
         </div>
@@ -100,7 +103,7 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12 sm:mb-16 animate-fade-in">
             <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
-              Our Services
+              Our ITAD Services
             </h2>
             <p className="text-lg sm:text-xl text-gray-600 max-w-3xl mx-auto px-2">
               Certified data destruction and sanitization, free equipment pickup,
@@ -223,7 +226,8 @@ export default function Home() {
               </h3>
               <p className="text-gray-600 mb-6 group-hover:text-gray-700 transition-colors">
                 Environmentally responsible recycling of electronic equipment
-                following industry best practices and regulations.
+                with documented downstream tracking and zero landfill for
+                hazardous material.
               </p>
               <div className="flex items-center text-primary-green font-semibold group-hover:text-primary-green-dark transition-colors">
                 Learn More
@@ -257,7 +261,7 @@ export default function Home() {
               <p className="text-lg sm:text-xl text-gray-600 mb-6 sm:mb-8 px-2 sm:px-0">
                 Serving Georgia and Southeast businesses with reliable data
                 destruction, responsible electronics recycling, and IT Asset
-                Recovery services you can trust.
+                Disposition (ITAD) services.
               </p>
 
               <div className="space-y-6">
@@ -305,8 +309,9 @@ export default function Home() {
                       Comprehensive Compliance
                     </h3>
                     <p className="text-gray-600">
-                      HIPAA, SOX, GLBA, and FACTA compliant processes ensure
-                      your regulatory requirements are met.
+                      Documented chain of custody and NIST 800-88 sanitization
+                      supporting HIPAA, SOX, GLBA, and FACTA requirements.
+                      Serialized certificate of destruction on every device.
                     </p>
                   </div>
                 </div>
@@ -330,8 +335,8 @@ export default function Home() {
                       Enterprise Support
                     </h3>
                     <p className="text-gray-600">
-                      Dedicated account managers and enterprise support for
-                      large-scale corporate clients.
+                      Dedicated account manager, 24–48 hour scheduled pickup,
+                      and audit reporting within 5–10 business days.
                     </p>
                   </div>
                 </div>
@@ -363,10 +368,12 @@ export default function Home() {
                   <div className="text-center">
                     <div className="w-16 h-16 bg-white bg-opacity-20 rounded-full flex items-center justify-center mx-auto mb-3">
                       <span className="text-xl font-bold text-primary-green">
-                        EPA
+                        B
                       </span>
                     </div>
-                    <div className="font-semibold">EPA Compliant</div>
+                    <div className="font-semibold leading-tight">
+                      R2v3 Appendix B — Data Sanitization
+                    </div>
                   </div>
                   <div className="text-center">
                     <div className="w-16 h-16 bg-white bg-opacity-20 rounded-full flex items-center justify-center mx-auto mb-3">
@@ -386,34 +393,11 @@ export default function Home() {
       {/* Service Areas */}
       <section className="pt-8 sm:pt-10 pb-16 sm:pb-20 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-8">
-            <h2 className="text-3xl font-bold text-gray-900 mb-4">
+          <div className="text-center mb-6 sm:mb-8">
+            <h2 className="text-3xl font-bold text-gray-900 mb-6 sm:mb-8">
               Serving All of Georgia
             </h2>
-            <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-              Professional data destruction, electronics recycling, and IT equipment pickup services throughout Georgia and Southeast States
-            </p>
-          </div>
-
-          <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 text-center">
-            {[
-              "Atlanta",
-              "Marietta",
-              "Augusta",
-              "Columbus",
-              "Macon",
-              "Suwanee",
-              "Decatur",
-              "Roswell",
-              "Sandy Springs",
-              "Lawrenceville",
-              "Johns Creek",
-              "Alpharetta",
-            ].map((city) => (
-              <div key={city} className="bg-gray-50 rounded-lg p-4">
-                <p className="font-semibold text-gray-900">{city}</p>
-              </div>
-            ))}
+            <ServiceAreaCallout />
           </div>
         </div>
       </section>

--- a/src/app/service-area/georgia/layout.tsx
+++ b/src/app/service-area/georgia/layout.tsx
@@ -4,8 +4,6 @@ export const metadata: Metadata = {
   title: "Electronics Recycling & Data Destruction Georgia | Computer Recyclers USA",
   description:
     "Statewide electronics recycling and data destruction for Georgia businesses. R2 certified, HIPAA-aligned. Data sanitization, free pickup, responsible recycling across Georgia.",
-  keywords:
-    "electronics recycling Georgia, data destruction Georgia, IT equipment pickup Georgia, R2 certified, statewide service",
   alternates: {
     canonical: "https://www.crusallc.com/service-area/georgia",
   },

--- a/src/app/services/data-destruction/layout.tsx
+++ b/src/app/services/data-destruction/layout.tsx
@@ -4,8 +4,6 @@ export const metadata: Metadata = {
   title: "Data Destruction Georgia | Computer Recyclers USA",
   description:
     "Data destruction Georgia per NIST 800-88. R2v3 Appendix B physical shredding and logical sanitization. Free pickup, certificates in 5–10 days.",
-  keywords:
-    "data destruction Georgia, NIST 800-88, data sanitization Georgia, hard drive shredding, R2v3 Appendix B, certified data destruction Atlanta",
   alternates: {
     canonical: "https://www.crusallc.com/services/data-destruction",
   },

--- a/src/app/services/data-sanitization/layout.tsx
+++ b/src/app/services/data-sanitization/layout.tsx
@@ -4,8 +4,6 @@ export const metadata: Metadata = {
   title: "Data Sanitization Georgia | Computer Recyclers USA",
   description:
     "Certified data sanitization and hard drive wiping Georgia. R2v3 Appendix B logical erasure between NIST Clear and Purge. Retain reuse value.",
-  keywords:
-    "data sanitization, hard drive wiping Georgia, certified data erasure, R2v3 Appendix B, logical sanitization, NIST 800-88 purge",
   alternates: {
     canonical: "https://www.crusallc.com/services/data-sanitization",
   },

--- a/src/app/services/free-it-equipment-pickup/layout.tsx
+++ b/src/app/services/free-it-equipment-pickup/layout.tsx
@@ -4,8 +4,6 @@ export const metadata: Metadata = {
   title: "Free IT Equipment Pickup Atlanta Georgia | Computer Recyclers USA",
   description:
     "Free business IT equipment pickup in Atlanta and Georgia. R2 certified, professional service for corporate organizations. Schedule complimentary pickup today.",
-  keywords:
-    "free IT equipment pickup atlanta, recycle computers atlanta, computer pickup atlanta, IT disposal georgia, electronics pickup service, R2 certified",
   alternates: {
     canonical: "https://www.crusallc.com/services/free-it-equipment-pickup",
   },

--- a/src/app/services/free-it-equipment-pickup/page.tsx
+++ b/src/app/services/free-it-equipment-pickup/page.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import Link from "next/link";
 import PickupForm from "@/components/PickupForm";
 import Header from "@/components/Header";
 import ParticleBackground from "@/components/ParticleBackground";
 import StructuredData from "@/components/StructuredData";
+import ServiceAreaCallout from "@/components/ServiceAreaCallout";
 import { Analytics } from "@vercel/analytics/react";
 
 export default function FreeITEquipmentPickup() {
@@ -440,40 +440,10 @@ export default function FreeITEquipmentPickup() {
           {/* Service Areas */}
           <div className="mb-16">
             <div className="text-center mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-4">
+              <h2 className="text-3xl font-bold text-gray-900 mb-6 sm:mb-8">
                 Free Pickup Throughout Georgia
               </h2>
-              <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-                Professional IT equipment pickup services available across{" "}
-                <Link
-                  href="/service-area/georgia"
-                  className="text-primary-green hover:text-primary-green-dark font-bold"
-                >
-                  Georgia
-                </Link>{" "}
-                cities and counties
-              </p>
-            </div>
-
-            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 text-center">
-              {[
-                "Atlanta",
-                "Marietta",
-                "Augusta",
-                "Columbus",
-                "Macon",
-                "Suwanee",
-                "Decatur",
-                "Roswell",
-                "Sandy Springs",
-                "Lawrenceville",
-                "Johns Creek",
-                "Alpharetta",
-              ].map((city) => (
-                <div key={city} className="bg-gray-50 rounded-lg p-4">
-                  <p className="font-semibold text-gray-900">{city}</p>
-                </div>
-              ))}
+              <ServiceAreaCallout />
             </div>
           </div>
         </div>

--- a/src/app/services/hard-drive-shredding/layout.tsx
+++ b/src/app/services/hard-drive-shredding/layout.tsx
@@ -4,8 +4,6 @@ export const metadata: Metadata = {
   title: "Hard Drive Shredding Atlanta | Computer Recyclers USA",
   description:
     "Hard drive shredding Atlanta and Georgia. HDD & SSD physical destruction under R2v3 Appendix B. Serialized certificates, free business pickup. Schedule today.",
-  keywords:
-    "hard drive shredding Atlanta, SSD shredding Georgia, physical data destruction, R2v3 Appendix B, certificate of destruction, hard drive destruction Atlanta",
   alternates: {
     canonical: "https://www.crusallc.com/services/hard-drive-shredding",
   },

--- a/src/app/services/hard-drive-shredding/page.tsx
+++ b/src/app/services/hard-drive-shredding/page.tsx
@@ -7,6 +7,7 @@ import PickupForm from "@/components/PickupForm";
 import Header from "@/components/Header";
 import ParticleBackground from "@/components/ParticleBackground";
 import StructuredData from "@/components/StructuredData";
+import ServiceAreaCallout from "@/components/ServiceAreaCallout";
 import { Analytics } from "@vercel/analytics/react";
 
 export default function HardDriveShredding() {
@@ -271,43 +272,16 @@ export default function HardDriveShredding() {
 
           <div className="mb-16">
             <div className="text-center mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-4">
+              <h2 className="text-3xl font-bold text-gray-900 mb-6 sm:mb-8">
                 Pickup & Drop-Off Across Georgia
               </h2>
-              <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-                Free business pickup throughout{" "}
-                <Link
-                  href="/service-area/georgia"
-                  className="text-primary-green hover:text-primary-green-dark font-bold"
-                >
-                  Georgia
-                </Link>
-                , subject to logistics-based volume minimums. Individuals may
-                drop off at our Suwanee facility, 3644 Burnette Road, during
-                business hours (Mon–Fri 9:30AM–4:30PM EST).
-              </p>
+              <ServiceAreaCallout>
+                Free business pickup, subject to logistics-based volume
+                minimums. Individuals may drop off at our Suwanee facility, 3644
+                Burnette Road, during business hours (Mon–Fri 9:30AM–4:30PM EST).
+              </ServiceAreaCallout>
             </div>
-            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 text-center mb-8">
-              {[
-                "Atlanta",
-                "Marietta",
-                "Augusta",
-                "Columbus",
-                "Macon",
-                "Suwanee",
-                "Decatur",
-                "Roswell",
-                "Sandy Springs",
-                "Lawrenceville",
-                "Johns Creek",
-                "Alpharetta",
-              ].map((city) => (
-                <div key={city} className="bg-gray-50 rounded-lg p-4">
-                  <p className="font-semibold text-gray-900">{city}</p>
-                </div>
-              ))}
-            </div>
-            <div className="text-center">
+            <div className="text-center mt-8">
               <button
                 onClick={() => setShowPickupForm(true)}
                 className="bg-primary-green hover:bg-primary-green-dark text-white px-8 sm:px-12 py-3 sm:py-4 rounded-lg font-semibold text-base sm:text-lg transition-all duration-300 hover:scale-105 shadow-lg hover:shadow-xl"

--- a/src/app/services/layout.tsx
+++ b/src/app/services/layout.tsx
@@ -1,22 +1,17 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title:
-    "Our Services - Computer Recyclers USA | Data Destruction & Electronics Recycling",
+  title: "Our ITAD Services | Computer Recyclers USA",
   description:
     "Professional electronics recycling and secure data destruction services in Georgia. R2 v3 certified, environmentally responsible e-waste disposal.",
-  keywords:
-    "electronics recycling services, data destruction services, computer recycling Georgia, secure data destruction, e-waste disposal services",
   openGraph: {
-    title:
-      "Our Services - Computer Recyclers USA | Data Destruction & Electronics Recycling",
+    title: "Our ITAD Services | Computer Recyclers USA",
     description:
       "Professional electronics recycling and secure data destruction services in Georgia. R2 v3 certified, environmentally responsible e-waste disposal.",
     url: "https://www.crusallc.com/services",
   },
   twitter: {
-    title:
-      "Our Services - Computer Recyclers USA | Data Destruction & Electronics Recycling",
+    title: "Our ITAD Services | Computer Recyclers USA",
     description:
       "Professional electronics recycling and secure data destruction services in Georgia. R2 v3 certified, environmentally responsible e-waste disposal.",
   },

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -20,7 +20,7 @@ export default function Services() {
         <div className="relative z-[1] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center animate-fade-in">
             <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-gray-900 mb-4 sm:mb-6">
-              Our <span className="text-primary-green">Services</span>
+              Our <span className="text-primary-green">ITAD Services</span>
             </h1>
             <p className="text-lg sm:text-xl md:text-2xl text-gray-600 max-w-4xl mx-auto mb-6 sm:mb-8 px-2">
               <strong>
@@ -454,13 +454,13 @@ export default function Services() {
                     </div>
                     <div>
                       <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                        EPA Compliance
+                        R2v3 Appendix B — Data Sanitization
                       </h3>
                       <p className="text-gray-600">
                         <strong>
-                          All recycling processes meet or exceed EPA guidelines
-                          and state environmental regulations for electronic
-                          waste handling and processing.
+                          Certified physical shredding and logical sanitization
+                          under R2v3 Appendix B, with documented downstream
+                          tracking for recycled materials.
                         </strong>
                       </p>
                     </div>

--- a/src/app/services/responsible-electronics-recycling/layout.tsx
+++ b/src/app/services/responsible-electronics-recycling/layout.tsx
@@ -4,8 +4,6 @@ export const metadata: Metadata = {
   title: "Recycle Electronics & E-Waste Georgia | Computer Recyclers USA",
   description:
     "Recycle electronics and e-waste responsibly in Georgia. R2 certified facility, zero landfill, free pickup. Serving Atlanta metro & Southeast.",
-  keywords:
-    "recycle electronics, e-waste, electronics recycling georgia, recycle electronics atlanta, e-waste disposal, responsible electronics recycling, R2 certified",
   alternates: {
     canonical: "https://www.crusallc.com/services/responsible-electronics-recycling",
   },

--- a/src/app/services/responsible-electronics-recycling/page.tsx
+++ b/src/app/services/responsible-electronics-recycling/page.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import Link from "next/link";
 import PickupForm from "@/components/PickupForm";
 import Header from "@/components/Header";
 import ParticleBackground from "@/components/ParticleBackground";
 import StructuredData from "@/components/StructuredData";
+import ServiceAreaCallout from "@/components/ServiceAreaCallout";
 import { Analytics } from "@vercel/analytics/react";
 
 export default function ResponsibleElectronicsRecycling() {
@@ -17,7 +17,7 @@ export default function ResponsibleElectronicsRecycling() {
     "@type": "Service",
     name: "Responsible Electronics Recycling Services",
     description:
-      "R2 v3 certified electronics recycling in Georgia. Zero landfill guarantee, EPA compliant processes, detailed environmental impact reporting.",
+      "R2 v3 certified electronics recycling in Georgia. Zero landfill guarantee, documented downstream tracking, detailed environmental impact reporting.",
     provider: {
       "@id": "https://www.crusallc.com/#organization",
     },
@@ -121,10 +121,11 @@ export default function ResponsibleElectronicsRecycling() {
                 </div>
                 <div className="bg-gray-50 p-6 rounded-lg">
                   <h3 className="font-bold text-lg text-gray-900 mb-2">
-                    EPA Compliant
+                    Downstream Tracking
                   </h3>
                   <p className="text-gray-600">
-                    Exceeds all environmental standards
+                    Documented downstream tracking and zero landfill for
+                    hazardous material
                   </p>
                 </div>
                 <div className="bg-gray-50 p-6 rounded-lg">
@@ -192,8 +193,8 @@ export default function ResponsibleElectronicsRecycling() {
                   Compliance Record
                 </div>
                 <p className="text-gray-600">
-                  Perfect compliance with all EPA and state environmental
-                  regulations
+                  Documented downstream tracking and zero landfill for hazardous
+                  material
                 </p>
               </div>
             </div>
@@ -474,40 +475,10 @@ export default function ResponsibleElectronicsRecycling() {
           {/* Service Areas */}
           <div className="mb-16">
             <div className="text-center mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-4">
+              <h2 className="text-3xl font-bold text-gray-900 mb-6 sm:mb-8">
                 Serving All of Georgia
               </h2>
-              <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-                R2 v3 certified electronics recycling services throughout{" "}
-                <Link
-                  href="/service-area/georgia"
-                  className="text-primary-green hover:text-primary-green-dark font-bold"
-                >
-                  Georgia
-                </Link>{" "}
-                and Southeast States
-              </p>
-            </div>
-
-            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 text-center">
-              {[
-                "Atlanta",
-                "Marietta",
-                "Augusta",
-                "Columbus",
-                "Macon",
-                "Suwanee",
-                "Decatur",
-                "Roswell",
-                "Sandy Springs",
-                "Lawrenceville",
-                "Johns Creek",
-                "Alpharetta",
-              ].map((city) => (
-                <div key={city} className="bg-gray-50 rounded-lg p-4">
-                  <p className="font-semibold text-gray-900">{city}</p>
-                </div>
-              ))}
+              <ServiceAreaCallout />
             </div>
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12 sm:mb-16">
             <h2 className="text-3xl sm:text-4xl font-bold mb-4">
-              Ready to Get Started?
+              Get a Quote or Schedule a Pickup
             </h2>
             <p className="text-lg sm:text-xl text-gray-300 max-w-3xl mx-auto px-2">
               Join over 700+{" "}
@@ -76,7 +76,7 @@ export default function Footer() {
               </a>
               <h3 className="text-xl font-bold mb-2">Email Us</h3>
               <p className="text-gray-300 mb-2">info@crusallc.com</p>
-              <p className="text-sm text-gray-400">Response within 24 hours</p>
+              <p className="text-sm text-gray-400">Quote within one business day</p>
             </div>
 
             <div className="text-center">
@@ -111,7 +111,9 @@ export default function Footer() {
               <h3 className="text-xl font-bold mb-2">Visit Us</h3>
               <p className="text-gray-300 mb-2">3644 Burnette Rd</p>
               <p className="text-gray-300 mb-2">Suwanee, GA 30024</p>
-              <p className="text-sm text-gray-400">Secure Facility</p>
+              <p className="text-sm text-gray-400">
+                R2v3-certified facility · Access controlled · CCTV monitored
+              </p>
             </div>
           </div>
 

--- a/src/components/PickupForm.tsx
+++ b/src/components/PickupForm.tsx
@@ -815,7 +815,7 @@ export default function PickupForm({ onClose }: PickupFormProps) {
                     clipRule="evenodd"
                   />
                 </svg>
-                Response within 24 hours
+                Quote within one business day
               </div>
             </div>
           </div>

--- a/src/components/ServiceAreaCallout.tsx
+++ b/src/components/ServiceAreaCallout.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+const CITIES = ["Atlanta", "Marietta", "Alpharetta", "Vinings"] as const;
+
+type ServiceAreaCalloutProps = {
+  /** Extra copy under the city line (e.g. pickup logistics). */
+  children?: ReactNode;
+  className?: string;
+};
+
+export default function ServiceAreaCallout({
+  children,
+  className = "",
+}: ServiceAreaCalloutProps) {
+  return (
+    <div className={`text-center ${className}`}>
+      <div className="inline-flex items-center justify-center gap-2 mb-4 text-primary-green">
+        <svg
+          className="w-5 h-5 shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+        </svg>
+        <span className="text-xs sm:text-sm font-semibold uppercase tracking-[0.22em]">
+          Statewide Coverage
+        </span>
+      </div>
+
+      <p className="text-xl sm:text-2xl md:text-3xl font-semibold text-gray-900 leading-snug tracking-tight">
+        {CITIES.map((city, i) => (
+          <span key={city}>
+            {i > 0 && (
+              <span className="mx-2 sm:mx-3 text-primary-green/40 font-light select-none">
+                ·
+              </span>
+            )}
+            <span className="text-primary-green">{city}</span>
+          </span>
+        ))}
+      </p>
+
+      <p className="mt-3 text-base sm:text-lg text-gray-600">
+        and all of{" "}
+        <Link
+          href="/service-area/georgia"
+          className="text-primary-green hover:text-primary-green-dark font-bold underline decoration-primary-green/30 underline-offset-4 hover:decoration-primary-green transition-colors"
+        >
+          Georgia
+        </Link>
+      </p>
+
+      {children && (
+        <p className="mt-4 text-sm sm:text-base text-gray-500 max-w-2xl mx-auto leading-relaxed">
+          {children}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Update titles, descriptions, and body copy to emphasize R2v3/ITAD specifics, remove unused keywords and EPA-as-certification claims, and replace city grids with a branded service-area callout.